### PR TITLE
Inversion du hostname et du mot de passe lors de l'initialisation

### DIFF
--- a/bboxpy/bbox.py
+++ b/bboxpy/bbox.py
@@ -23,7 +23,7 @@ class Bbox(BboxRequests):
         use_tls: bool = True,
     ) -> None:
         """Initialize."""
-        super().__init__(hostname, password, timeout, session, use_tls)
+        super().__init__(password, hostname, timeout, session, use_tls)
         self._load_modules()
 
     def _load_modules(self) -> None:


### PR DESCRIPTION
Il y a une inversion du _hostname_ et du mot de passe lors de l'initialisation lors de la `BboxRequests` depuis `Bbox.__init__`.

PS : je suis en train de tenter une utilisation de votre intégration _bbox2_ pour HA et j'ai pas fini de debugguer mes problèmes, d'autres PR probablement à venir :wink: 