### PR TITLE
Correction de la possibilité d'importer la lib en dehors d'une boucle asyncio

### DIFF
--- a/bboxpy/auth.py
+++ b/bboxpy/auth.py
@@ -6,7 +6,7 @@ import asyncio
 import json
 import logging
 import socket
-from typing import Any, cast
+from typing import Any, cast, Optional
 
 from aiohttp import ClientError, ClientResponse, ClientResponseError, ClientSession
 
@@ -23,17 +23,16 @@ class BboxRequests:
     def __init__(
         self,
         password: str,
-        hostname: str = "mabbox.bytel.fr",
-        timeout: int = 120,
-        session: ClientSession = None,
+        hostname: Optional[str] = None,
+        timeout: Optional[int] = None,
+        session: Optional[ClientSession] = None,
         use_tls: bool = True,
     ) -> None:
         """Initialize."""
         self.password = password
-        self._session = session
-        self._timeout = timeout
-        scheme = "https" if use_tls else "http"
-        self._uri = f"{scheme}://{hostname}/{API_VERSION}"
+        self._session = session or ClientSession()
+        self._timeout = timeout or 120
+        self._uri = f"http{'s' if use_tls else ''}://{hostname or 'mabbox.bytel.fr'}/{API_VERSION}"
 
     async def async_request(self, path: str, method: str = "get", **kwargs: Any) -> Any:
         """Request url with method."""

--- a/bboxpy/bbox.py
+++ b/bboxpy/bbox.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import inspect
 
-from aiohttp import ClientSession
+from typing import Any
+
 
 from . import api as Api
 from .auth import BboxRequests
@@ -14,16 +15,9 @@ from .exceptions import AuthorizationError, BboxException
 class Bbox(BboxRequests):
     """API Bouygues Bbox router."""
 
-    def __init__(
-        self,
-        password: str,
-        hostname: str = "mabbox.bytel.fr",
-        timeout: int = 120,
-        session: ClientSession = ClientSession(),
-        use_tls: bool = True,
-    ) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize."""
-        super().__init__(hostname, password, timeout, session, use_tls)
+        super().__init__(*args, **kwargs)
         self._load_modules()
 
     def _load_modules(self) -> None:


### PR DESCRIPTION
Le fait d'appeler la `ClientSession()` comme valeur par défaut du paramètre `session` de Bbox.__init__` empechait l'import de la lib en dehors d'une boucle `asyncio`. Ci-dessous un exemple d'exception que cela produisait :

```
Traceback (most recent call last):
  File "/home/brenard/dev/bboxpy/test.py", line 5, in <module>
    from bboxpy import Bbox
  File "/home/brenard/dev/bboxpy/bboxpy/__init__.py", line 3, in <module>
    from .bbox import Bbox
  File "/home/brenard/dev/bboxpy/bboxpy/bbox.py", line 14, in <module>
    class Bbox(BboxRequests):
  File "/home/brenard/dev/bboxpy/bboxpy/bbox.py", line 22, in Bbox
    session: ClientSession = ClientSession(),
                             ^^^^^^^^^^^^^^^
  File "/home/brenard/dev/bboxpy/venv/lib/python3.11/site-packages/aiohttp/client.py", line 298, in __init__
    loop = loop or asyncio.get_running_loop()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
```