### PR TITLE
Ajout d'un module parentalcontrol

### DIFF
--- a/bboxpy/api/__init__.py
+++ b/bboxpy/api/__init__.py
@@ -6,5 +6,6 @@ from .iptv import IPTv
 from .lan import Lan
 from .voip import VOIP
 from .wan import Wan
+from .parentalcontrol import ParentalControl
 
-__all__ = ["Device", "Lan", "Wan", "VOIP", "IPTv", "Ddns"]
+__all__ = ["Ddns", "Device", "IPTv", "Lan", "ParentalControl", "VOIP", "Wan"]

--- a/bboxpy/api/parentalcontrol.py
+++ b/bboxpy/api/parentalcontrol.py
@@ -1,0 +1,32 @@
+"""Parental Control"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+
+class ParentalControl:
+    """Parental control information."""
+
+    def __init__(self, request: Callable[..., Any]) -> None:
+        """Initialize."""
+        self.async_request = request
+
+    async def async_set_parental_control_service_state(self, enable: bool) -> Any:
+        """Set parental control service state."""
+        return await self.async_request(
+            "parentalcontrol",
+            method="put",
+            data={"enable": int(enable)},
+        )
+
+    async def async_set_device_parental_control_state(
+        self, macaddress: str, enable: bool
+    ) -> Any:
+        """Set device parental control state."""
+        return await self.async_request(
+            "parentalcontrol/hosts",
+            method="put",
+            data={"macaddress": macaddress, "enable": int(enable)},
+        )


### PR DESCRIPTION
J'ai ajouté un module `parentalcontrol` permettant aujourd'hui de contrôler l'état du service _Contrôle d'accès_ de la Bbox ainsi que l'état du contrôle d'accès des équipements.

PS : le choix du nom _parentalcontrol_ vient du fait que c'est sous ce nom que la Bbox expose cela dans son API.
PPS : le but de cette PR est d'ajouter des _switchs_ pour contrôler cela depuis Home Assistant dans votre composant  bbox2 (à venir).